### PR TITLE
example: Fix plugged typo in LevelSensor

### DIFF
--- a/examples/LevelSensor/LevelSensor.ino
+++ b/examples/LevelSensor/LevelSensor.ino
@@ -13,7 +13,7 @@
 #include <EthernetWebThingAdapter.h>
 
 const char* deviceTypes[] = {"MultiLevelSensor", "Sensor", nullptr};
-ThingDevice device("AnalogSensorDevice", "Analog Sensor pluged in single pin", deviceTypes);
+ThingDevice device("AnalogSensorDevice", "Analog Sensor plugged in single pin", deviceTypes);
 ThingProperty property("level", "Analog Input pin", NUMBER, "LevelProperty");
 WebThingAdapter* adapter = NULL;
 

--- a/examples/LevelSensor/README.md
+++ b/examples/LevelSensor/README.md
@@ -34,7 +34,7 @@ curl http://192.168.1.225/
         "Sensor"
       ],
     "href" : "/things/AnalogSensorDevice",
-    "name" : "Analog Sensor pluged in single pin",
+    "name" : "Analog Sensor plugged in single pin",
     "properties" : { "level" : { 
             "@type" : "LevelProperty",
             "href" : "/things/AnalogSensorDevice/properties/level",
@@ -50,7 +50,7 @@ curl http://192.168.1.225/things/AnalogSensorDevice/properties/level
 Then it can be added to gateway.
 
 Note, you may need to change the hardcoded MAC address,
-if you run this example on several devices of your LAN/
+if you run this example on several devices of your LAN.
 
 
 ## DEMO: ##


### PR DESCRIPTION
Change-Id: If6e584a43cf9f064b0c032ad66d45e76dc1b528f
Signed-off-by: Philippe Coval <p.coval@samsung.com>