### PR TITLE
example: Fix warning by adding cast on I2C address of BME280

### DIFF
--- a/examples/PlatformIO/BME280/src/BME280.cpp
+++ b/examples/PlatformIO/BME280/src/BME280.cpp
@@ -59,7 +59,7 @@ BME280I2C::Settings settings(
    BME280::StandbyTime_1000ms,
    BME280::Filter_Off,
    BME280::SpiEnable_False,
-   0x76 // I2C address. I2C specific.
+   (BME280I2C::I2CAddr) 0x76 // I2C address. I2C specific.
 );
 
 BME280I2C bme(settings);


### PR DESCRIPTION
This will unblock the CI checker.

Change-Id: I03146de16ee948d880d450306cf1b34bdbbfbc15
Signed-off-by: Philippe Coval <p.coval@samsung.com>