### PR TITLE
add wait for serial before printing

### DIFF
--- a/examples/LED/LED.ino
+++ b/examples/LED/LED.ino
@@ -35,6 +35,9 @@ void setup(void){
   pinMode(ledPin, OUTPUT);
   digitalWrite(ledPin, HIGH);
   Serial.begin(115200);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
   Serial.println("");
   Serial.print("Connecting to \"");
   Serial.print(ssid);
@@ -83,4 +86,3 @@ void loop(void){
   }
   lastOn = on;
 }
-


### PR DESCRIPTION
I found that my feather M0 was a bit to slow and swallowed the ` Connecting to <ssid>` only printing the dots after it. so i found this workaround [here](https://www.arduino.cc/en/Reference/WiFi101Ping).