### PR TITLE
Make API server port changeable

### DIFF
--- a/ESPWebThingAdapter.h
+++ b/ESPWebThingAdapter.h
@@ -28,7 +28,7 @@
 
 class WebThingAdapter {
 public:
-  WebThingAdapter(String _name, IPAddress _ip): name(_name), server(80), ip(_ip.toString()) {
+  WebThingAdapter(String _name, IPAddress _ip, uint16_t _port = 80): name(_name), server(_port), ip(_ip.toString()), port(_port) {
   }
 
   void begin() {
@@ -36,7 +36,7 @@ public:
       Serial.println("MDNS responder started");
     }
 
-    MDNS.addService("webthing", "tcp", 80);
+    MDNS.addService("webthing", "tcp", port);
     MDNS.addServiceTxt("webthing", "tcp", "path", "/");
 
     DefaultHeaders::Instance().addHeader("Access-Control-Allow-Origin", "*");
@@ -91,6 +91,7 @@ private:
   AsyncWebServer server;
   String name;
   String ip;
+  uint16_t port;
   ThingDevice* firstDevice = nullptr;
   ThingDevice* lastDevice = nullptr;
   char body_data[ESP_MAX_PUT_BODY_SIZE];

--- a/EthernetWebThingAdapter.h
+++ b/EthernetWebThingAdapter.h
@@ -60,7 +60,7 @@ enum ReadState {
 
 class WebThingAdapter {
 public:
-  WebThingAdapter(String _name, uint32_t _ip): name(_name), server(80)
+  WebThingAdapter(String _name, uint32_t _ip, uint16_t _port = 80): name(_name), server(_port), port(_port)
 #ifdef CONFIG_MDNS
   , mdns(udp)
 #endif
@@ -80,7 +80,7 @@ public:
     mdns.begin(Ethernet.localIP(), name.c_str());
 
     mdns.addServiceRecord("_webthing",
-                          80,
+                          port,
                           MDNSServiceTCP,
                           "\x06path=/");
 #endif
@@ -219,6 +219,7 @@ public:
   }
 private:
   String name, ip;
+  uint16_t port;
   EthernetServer server;
   EthernetClient client;
 #ifdef CONFIG_MDNS

--- a/WiFi101WebThingAdapter.h
+++ b/WiFi101WebThingAdapter.h
@@ -41,7 +41,7 @@ enum ReadState {
 
 class WebThingAdapter {
 public:
-  WebThingAdapter(String _name, uint32_t _ip): name(_name), server(80), mdns(udp) {
+  WebThingAdapter(String _name, uint32_t _ip, uint16_t _port = 80): name(_name), server(_port), port(_port), mdns(udp) {
     ip = "";
     for (int i = 0; i < 4; i++) {
       ip += _ip & 0xff;
@@ -56,7 +56,7 @@ public:
     mdns.begin(WiFi.localIP(), name.c_str());
 
     mdns.addServiceRecord("_webthing",
-                          80,
+                          port,
                           MDNSServiceTCP,
                           "\x06path=/");
 
@@ -194,6 +194,7 @@ public:
   }
 private:
   String name, ip;
+  uint16_t port;
   WiFiServer server;
   WiFiClient client;
   WiFiUDP udp;


### PR DESCRIPTION
This PR makes WebThing API server port changeable from hardcoded '80'.

Example: 

```
// Default port is 80
adapter = new WebThingAdapter("human-sensor", WiFi.localIP())
// Now you can change port from 80 to any port you want
adapter = new WebThingAdapter("human-sensor", WiFi.localIP(), 8080)
```