### PR TITLE
Add platformio library.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *~
 **/build-*/*
 /tmp/
-
+.vscode
+.pioenvs
+.piolibdeps
+.pio

--- a/library.json
+++ b/library.json
@@ -1,0 +1,29 @@
+{
+    "name": "webthing-arduino",
+    "description": "A library for creating Web Things using the Web of Things API. Runs on ESP8266, ESP32, and WiFi101 boards. Compatible with the Mozilla IoT Gateway.",
+    "keywords": "Communication",
+    "version": "0.4.1",
+    "authors": {
+        "name": "Mozilla IoT <iot@mozilla.com>"
+    },
+    "repository":
+    {
+        "type": "git",
+        "url": "https://github.com/mozilla-iot/webthing-arduino"
+    },
+    "license": "Mozilla Public License Version 2.0",
+    "platforms": "espressif8266,espressif32,atmelavr",
+    "dependencies": {
+        "ArduinoJson": "5.13"
+    },
+    "export": {
+        "include":
+        [
+            "*.cpp",
+            "*.h"
+        ]
+    },
+    "examples": [
+        "examples/PlatformIO/*/src/*.cpp"
+    ]
+}


### PR DESCRIPTION
Right now there is only a library.properties file for the Arduino IDE ecosystem.
Platformio is a much easier experience and a corresponding library.json should be part of this repo.

The .gitignore file contains all pio runtime related directories as well now.

Signed-off-by: David Gräff <david.graeff@web.de>