### PR TITLE
Websockets support for the ESP Adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *~
 **/build-*/*
 /tmp/
-
+.vscode
+.pioenvs
+.piolibdeps
+.pio

--- a/ESPWebThingAdapter.h
+++ b/ESPWebThingAdapter.h
@@ -316,12 +316,12 @@ private:
       }
 
       // 2.9 Property object: A links array (An array of Link objects linking to one or more representations of a Property resource, each with an implied default rel=property.)
-      JsonObject& inline_links_prop = prop.createNestedObject("links");
+      JsonArray& inline_links = prop.createNestedArray("links");
+      JsonObject& inline_links_prop = inline_links.createNestedObject();
       inline_links_prop["href"] = propertiesBase + "/" + property->id;
 
       property = property->next;
     }
-  
   }
 
   void handleThing(AsyncWebServerRequest *request, ThingDevice*& device) {

--- a/library.json
+++ b/library.json
@@ -1,0 +1,29 @@
+{
+    "name": "webthing-arduino",
+    "description": "A library for creating Web Things using the Web of Things API. Runs on ESP8266, ESP32, and WiFi101 boards. Compatible with the Mozilla IoT Gateway.",
+    "keywords": "Communication",
+    "version": "0.4.1",
+    "authors": {
+        "name": "Mozilla IoT <iot@mozilla.com>"
+    },
+    "repository":
+    {
+        "type": "git",
+        "url": "https://github.com/mozilla-iot/webthing-arduino"
+    },
+    "license": "Mozilla Public License Version 2.0",
+    "platforms": "espressif8266,espressif32,atmelavr",
+    "dependencies": {
+        "ArduinoJson": "5.13"
+    },
+    "export": {
+        "include":
+        [
+            "*.cpp",
+            "*.h"
+        ]
+    },
+    "examples": [
+        "examples/PlatformIO/*/src/*.cpp"
+    ]
+}


### PR DESCRIPTION
The used async TCP/Http library also supports Websockets out of the box, no dependencies added.

As per spec, each Thing gets its own Websocket connection.

The property changed message is implemented by having a changed flag in each Thing Property.
The event loop will iterate over all Things and Properties and send a changed-property message if necessary and resets the flag.

Why not directly sending a changed message in the property setter method?
First, because there are no pointers back to the ThingAdapter and second the event loop must be the send initiator.The multicore ESP32 could otherwise cause potential concurrency issues.

An alternative of iterating over all Things and Properties would be a linked list of changed properties to save us from iterating over everything.

Because it is expected that only a few Things with only a few Properties are present on such a restricted device, it doesn't matter much though. For one Thing with one Property the runtime cost is the same even.

Signed-off-by: David Gräff <david.graeff@web.de>