### PR TITLE
example: Use analogWriteRange when possible in RGBLamp

### DIFF
--- a/examples/RGBLamp/RGBLamp.ino
+++ b/examples/RGBLamp/RGBLamp.ino
@@ -110,8 +110,9 @@ void setup(void) {
   Serial.print(WiFi.localIP());
   Serial.print("/things/");
   Serial.println(device.id);
-
+#ifdef analogWriteRange
   analogWriteRange(255);
+#endif
 }
 
 void update(String* color, int const level) {


### PR DESCRIPTION
Change-Id: Ib7917bfbcf4ffcfbf4d1630ef0d5b7ca4be6a674
Signed-off-by: Philippe Coval <p.coval@samsung.com>