### PR TITLE
example: Add build helper for RGBLamp

### DIFF
--- a/examples/RGBLamp/Makefile
+++ b/examples/RGBLamp/Makefile
@@ -41,6 +41,7 @@ CPPFLAGS+=-I${top_reldir}
 ARDUINO_LIBS += Ethernet SPI
 ARDUINO_LIBS += ArduinoMDNS
 ARDUINO_LIBS += ArduinoJson
+ARDUINO_LIBS += WiFi101
 
 -include ${arduino_mk}
 


### PR DESCRIPTION
For headless use

Change-Id: I6beeb3fa8fc4006b2aaa4e4617aba7537fe8881c
Signed-off-by: Philippe Coval <p.coval@samsung.com>