### PR TITLE
Added titles, units for properties and make them read-only

### DIFF
--- a/examples/BME280/BME280.ino
+++ b/examples/BME280/BME280.ino
@@ -124,7 +124,7 @@ void setup() {
   adapter = new WebThingAdapter("weathersensor", WiFi.localIP());
 
   // Set unit for temperature to degree celsius. Other option "fahrenheit"
-  weatherTemp.unit = "celsius";
+  weatherTemp.unit = "degree celsius";
   
   // Set title to "Pressure"
   weatherPres.title = "Pressure";

--- a/examples/BME280/BME280.ino
+++ b/examples/BME280/BME280.ino
@@ -50,7 +50,7 @@ WebThingAdapter *adapter;
 const char *bme280Types[] = {"TemperatureSensor", nullptr};
 ThingDevice weather("bme280", "BME280 Weather Sensor", bme280Types);
 ThingProperty weatherTemp("temperature", "", NUMBER, "TemperatureProperty");
-ThingProperty weatherHum("humidity", "", NUMBER, nullptr);
+ThingProperty weatherHum("humidity", "", NUMBER, "LevelProperty"); // Set humidity as level-property to show bar in gateway interface
 ThingProperty weatherPres("pressure", "", NUMBER, nullptr);
 
 BME280I2C::Settings
@@ -123,7 +123,23 @@ void setup() {
   digitalWrite(LED_BUILTIN, PIN_STATE_HIGH);
   adapter = new WebThingAdapter("weathersensor", WiFi.localIP());
 
+  // Set unit for temperature to "celsius". Other option "fahrenheit"
   weatherTemp.unit = "celsius";
+  
+  // Set title to "Pressure"
+  weatherPres.title = "Pressure";
+  // Set unit for pressure to hPa
+  weatherPres.unit = " hPa";
+  // Set pressure to read only (otherweise you may change the values in the gateway interface
+  weatherPres.readOnly = "true";
+  
+  // Set title to "Humidity"
+  weatherHum.title = "Humidity";
+  // Set unit for humidity to %
+  weatherHum.unit = "percent";
+  // Set humidity as read only (otherweise you may change the values in the gateway interface
+  weatherHum.readOnly = "true";
+  
   weather.addProperty(&weatherTemp);
   weather.addProperty(&weatherPres);
   weather.addProperty(&weatherHum);

--- a/examples/BME280/BME280.ino
+++ b/examples/BME280/BME280.ino
@@ -50,7 +50,7 @@ WebThingAdapter *adapter;
 const char *bme280Types[] = {"TemperatureSensor", nullptr};
 ThingDevice weather("bme280", "BME280 Weather Sensor", bme280Types);
 ThingProperty weatherTemp("temperature", "", NUMBER, "TemperatureProperty");
-ThingProperty weatherHum("humidity", "", NUMBER, "LevelProperty"); // Set humidity as level-property to show bar in gateway interface
+ThingProperty weatherHum("humidity", "", NUMBER, "LevelProperty"); // Set humidity as level-property
 ThingProperty weatherPres("pressure", "", NUMBER, nullptr);
 
 BME280I2C::Settings
@@ -123,23 +123,23 @@ void setup() {
   digitalWrite(LED_BUILTIN, PIN_STATE_HIGH);
   adapter = new WebThingAdapter("weathersensor", WiFi.localIP());
 
-  // Set unit for temperature to degree celsius. Other option "fahrenheit"
+  // Set unit for temperature
   weatherTemp.unit = "degree celsius";
   
   // Set title to "Pressure"
   weatherPres.title = "Pressure";
   // Set unit for pressure to hPa
   weatherPres.unit = "hPa";
-  // Set pressure to read only (otherweise you may change the values in the gateway interface)
+  // Set pressure to read only
   weatherPres.readOnly = "true";
   
   // Set title to "Humidity"
   weatherHum.title = "Humidity";
   // Set unit for humidity to %
   weatherHum.unit = "percent";
-  // Set humidity as read only (otherweise you may change the values in the gateway interface)
+  // Set humidity as read only
   weatherHum.readOnly = "true";
-  // Set minimum und maximum (for LevelProperty)
+  // Set min and max for LevelProperty
   weatherHum.minimum = 0;
   weatherHum.maximum = 100;
   

--- a/examples/BME280/BME280.ino
+++ b/examples/BME280/BME280.ino
@@ -123,22 +123,25 @@ void setup() {
   digitalWrite(LED_BUILTIN, PIN_STATE_HIGH);
   adapter = new WebThingAdapter("weathersensor", WiFi.localIP());
 
-  // Set unit for temperature to "celsius". Other option "fahrenheit"
+  // Set unit for temperature to degree celsius. Other option "fahrenheit"
   weatherTemp.unit = "celsius";
   
   // Set title to "Pressure"
   weatherPres.title = "Pressure";
   // Set unit for pressure to hPa
-  weatherPres.unit = " hPa";
-  // Set pressure to read only (otherweise you may change the values in the gateway interface
+  weatherPres.unit = "hPa";
+  // Set pressure to read only (otherweise you may change the values in the gateway interface)
   weatherPres.readOnly = "true";
   
   // Set title to "Humidity"
   weatherHum.title = "Humidity";
   // Set unit for humidity to %
   weatherHum.unit = "percent";
-  // Set humidity as read only (otherweise you may change the values in the gateway interface
+  // Set humidity as read only (otherweise you may change the values in the gateway interface)
   weatherHum.readOnly = "true";
+  // Set minimum und maximum (for LevelProperty)
+  weatherHum.minimum = 0;
+  weatherHum.maximum = 100;
   
   weather.addProperty(&weatherTemp);
   weather.addProperty(&weatherPres);

--- a/examples/BME280/BME280.ino
+++ b/examples/BME280/BME280.ino
@@ -50,7 +50,8 @@ WebThingAdapter *adapter;
 const char *bme280Types[] = {"TemperatureSensor", nullptr};
 ThingDevice weather("bme280", "BME280 Weather Sensor", bme280Types);
 ThingProperty weatherTemp("temperature", "", NUMBER, "TemperatureProperty");
-ThingProperty weatherHum("humidity", "", NUMBER, "LevelProperty"); // Set humidity as level-property
+// Set humidity as level-property
+ThingProperty weatherHum("humidity", "", NUMBER, "LevelProperty");
 ThingProperty weatherPres("pressure", "", NUMBER, nullptr);
 
 BME280I2C::Settings

--- a/examples/BME280/BME280.ino
+++ b/examples/BME280/BME280.ino
@@ -126,14 +126,14 @@ void setup() {
 
   // Set unit for temperature
   weatherTemp.unit = "degree celsius";
-  
+
   // Set title to "Pressure"
   weatherPres.title = "Pressure";
   // Set unit for pressure to hPa
   weatherPres.unit = "hPa";
   // Set pressure to read only
   weatherPres.readOnly = "true";
-  
+
   // Set title to "Humidity"
   weatherHum.title = "Humidity";
   // Set unit for humidity to %
@@ -143,7 +143,7 @@ void setup() {
   // Set min and max for LevelProperty
   weatherHum.minimum = 0;
   weatherHum.maximum = 100;
-  
+
   weather.addProperty(&weatherTemp);
   weather.addProperty(&weatherPres);
   weather.addProperty(&weatherHum);


### PR DESCRIPTION
This aims to make the Webthing be displayed correctly in the gateway interface. All sensor values should be read-only and have the correct corresponding units.