### PR TITLE
property won't set if it is read only.

### DIFF
--- a/Thing.h
+++ b/Thing.h
@@ -360,10 +360,6 @@ public:
       callback(newValue);
     }
   }
-  bool isInRange(ThingDataValue value){
-    return (this->maximum < this->minimum) //to check if minimum and maximum values are asigned
-    || (this->maximum > value.)
-  }
 };
 
 #ifndef WITHOUT_WS
@@ -602,7 +598,7 @@ public:
     case NUMBER: {
       ThingDataValue value;
       value.number = newValue.as<double>();
-      if((property->maximum < property->minimum) || (property->maximum > value && property->minimum < value)){
+      if((property->maximum < property->minimum) || (property->maximum > value.number && property->minimum < value.number)){
         property->setValue(value);
         property->changed(value);
       }
@@ -611,7 +607,7 @@ public:
     case INTEGER: {
       ThingDataValue value;
       value.integer = newValue.as<signed long long>();
-      if((property->maximum < property->minimum) || (property->maximum > value && property->minimum < value)){
+      if((property->maximum < property->minimum) || (property->maximum > value.integer && property->minimum < value.integer)){
         property->setValue(value);
         property->changed(value);
       }

--- a/Thing.h
+++ b/Thing.h
@@ -360,6 +360,10 @@ public:
       callback(newValue);
     }
   }
+  bool isInRange(ThingDataValue value){
+    return (this->maximum < this->minimum) //to check if minimum and maximum values are asigned
+    || (this->maximum > value.)
+  }
 };
 
 #ifndef WITHOUT_WS
@@ -578,7 +582,8 @@ public:
 
   void setProperty(const char *name, const JsonVariant &newValue) {
     ThingProperty *property = findProperty(name);
-
+    if(property->readOnly)
+      return;
     if (property == nullptr) {
       return;
     }
@@ -597,15 +602,19 @@ public:
     case NUMBER: {
       ThingDataValue value;
       value.number = newValue.as<double>();
-      property->setValue(value);
-      property->changed(value);
+      if((property->maximum < property->minimum) || (property->maximum > value && property->minimum < value)){
+        property->setValue(value);
+        property->changed(value);
+      }
       break;
     }
     case INTEGER: {
       ThingDataValue value;
       value.integer = newValue.as<signed long long>();
-      property->setValue(value);
-      property->changed(value);
+      if((property->maximum < property->minimum) || (property->maximum > value && property->minimum < value)){
+        property->setValue(value);
+        property->changed(value);
+      }
       break;
     }
     case STRING:


### PR DESCRIPTION
Hi, 
I noticed that read only parameter is not used. If a user put value to a read only property it will be accepted.
Also about integer and number properties if the put property be less than minimum or more than maximum the server wouldn't care and accept the new value for the property. 
I made some changes to prevent accept new value in mentioned case. 